### PR TITLE
Add PYTHONUTF8 environment variable to DevChat

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -199,6 +199,7 @@ class DevChat {
 				maxBuffer: 10 * 1024 * 1024, // Set maxBuffer to 10 MB
 				cwd: workspaceDir,
 				env: {
+					PYTHONUTF8:1,
 					...process.env,
 					OPENAI_API_KEY: openaiApiKey,
 					...openAiApiBaseObject

--- a/src/util/uiUtil_vscode.ts
+++ b/src/util/uiUtil_vscode.ts
@@ -18,9 +18,14 @@ export class UiUtilVscode implements UiUtil {
 		return vscode.workspace.getConfiguration(key1).get(key2);
 	}
 	public async secretStorageGet(key: string): Promise<string | undefined> {
-		const secretStorage: vscode.SecretStorage = ExtensionContextHolder.context!.secrets;
-		let openaiApiKey = await secretStorage.get(key);
-		return openaiApiKey;
+		try {
+			const secretStorage: vscode.SecretStorage = ExtensionContextHolder.context!.secrets;
+			let openaiApiKey = await secretStorage.get(key);
+			return openaiApiKey;
+		} catch (error) {
+			logger.channel()?.error(`secretStorageGet error: ${error}`);
+			return undefined;
+		}
 	}
 	public async writeFile(uri: string, content: string): Promise<void> {
 		await vscode.workspace.fs.writeFile(vscode.Uri.file(uri), Buffer.from(content));


### PR DESCRIPTION
- Set PYTHONUTF8 to 1 in the DevChat class.
- Ensures proper handling of UTF-8 encoding.