### PR TITLE
Prevent sending message on Enter key press during IME composition

### DIFF
--- a/src/views/InputMessage.tsx
+++ b/src/views/InputMessage.tsx
@@ -205,7 +205,7 @@ const InputMessage = (props: any) => {
                 }
             }
         } else {
-            if (event.key === 'Enter' && !event.shiftKey) {
+            if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
                 handleSendClick(event as any);
             }
         }


### PR DESCRIPTION
- Modified the condition in InputMessage.tsx to check if the IME composition is in progress.
- This prevents the message from being sent when the Enter key is pressed during IME composition.