### PR TITLE
Differentiate code block rendering based on message type

### DIFF
--- a/src/views/CodeBlock.tsx
+++ b/src/views/CodeBlock.tsx
@@ -8,7 +8,7 @@ import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism";
 import messageUtil from '@/util/MessageUtil';
 
 const CodeBlock = (props: any) => {
-    const { messageText } = props;
+    const { messageText, messageType } = props;
 
     const LanguageCorner = (props: any) => {
         const { language } = props;
@@ -121,31 +121,33 @@ const CodeBlock = (props: any) => {
     };
 
     return (
-        <ReactMarkdown
-            components={{
-                code({ node, inline, className, children, ...props }) {
+        messageType === 'bot'
+            ? <ReactMarkdown
+                components={{
+                    code({ node, inline, className, children, ...props }) {
 
-                    const match = /language-(\w+)/.exec(className || '');
-                    const value = String(children).replace(/\n$/, '');
+                        const match = /language-(\w+)/.exec(className || '');
+                        const value = String(children).replace(/\n$/, '');
 
-                    return !inline && match ? (
-                        <div style={{ position: 'relative' }}>
-                            <LanguageCorner language={match[1]} />
-                            <CodeButtons language={match[1]} code={value} />
-                            <SyntaxHighlighter {...props} language={match[1]} customStyle={{ padding: '3em 1em 1em 2em', }} style={okaidia} PreTag="div">
-                                {value}
-                            </SyntaxHighlighter>
-                        </div >
-                    ) : (
-                        <code {...props} className={className}>
-                            {children}
-                        </code>
-                    );
-                }
-            }}
-        >
-            {messageText}
-        </ReactMarkdown >
+                        return !inline && match ? (
+                            <div style={{ position: 'relative' }}>
+                                <LanguageCorner language={match[1]} />
+                                <CodeButtons language={match[1]} code={value} />
+                                <SyntaxHighlighter {...props} language={match[1]} customStyle={{ padding: '3em 1em 1em 2em', }} style={okaidia} PreTag="div">
+                                    {value}
+                                </SyntaxHighlighter>
+                            </div >
+                        ) : (
+                            <code {...props} className={className}>
+                                {children}
+                            </code>
+                        );
+                    }
+                }}
+            >
+                {messageText}
+            </ReactMarkdown >
+            : <pre>{messageText}</pre>
     );
 };
 

--- a/src/views/MessageContainer.tsx
+++ b/src/views/MessageContainer.tsx
@@ -193,7 +193,7 @@ const MessageContainer = (props: any) => {
                     },
                 }}>
                 <MessageContext key={`message-context-${index}`} contexts={contexts} />
-                <CodeBlock key={`message-codeblock-${index}`} messageText={messageText} />
+                <CodeBlock key={`message-codeblock-${index}`} messageType={messageType} messageText={messageText} />
                 <MessageBlink key={`message-blink-${index}`} messageType={messageType} lastMessage={index === messages.length - 1} />
             </Container >
             {index !== messages.length - 1 && <Divider my={3} key={`message-divider-${index}`} />}


### PR DESCRIPTION
- Added messageType prop to CodeBlock component in CodeBlock.tsx.
- CodeBlock now renders differently for 'bot' and other message types.
- Updated MessageContainer.tsx to pass messageType to CodeBlock.