### PR TITLE
Modify parent_hash assignment in sendMessage command

### DIFF
--- a/src/views/chatSlice.ts
+++ b/src/views/chatSlice.ts
@@ -67,7 +67,7 @@ export const chatSlice = createSlice({
             messageUtil.sendMessage({
                 command: 'sendMessage',
                 text: action.payload,
-                parent_hash: lastNonEmptyHash
+                parent_hash: lastNonEmptyHash === 'message' ? null : lastNonEmptyHash
             });
         },
         reGenerating: (state) => {


### PR DESCRIPTION
- Updated the assignment of parent_hash in the sendMessage command to be null when lastNonEmptyHash is 'message'.