### PR TITLE
Update condition in deleteMessage method

### DIFF
--- a/src/topic/topicManager.ts
+++ b/src/topic/topicManager.ts
@@ -117,7 +117,7 @@ export class TopicManager {
 
 	deleteMessage(topicId: string, messageHash: string): void {
 		const topic = this._topics[topicId];
-		if (topic) {
+		if (topic && messageHash === topic.firstMessageHash) {
 			topic.updateFirstMessageHashAndName(undefined, undefined);
 			topic.lastMessageHash = undefined;
 			this._notifyUpdateTopicListeners(topicId);


### PR DESCRIPTION
- Added a check to ensure the messageHash equals the firstMessageHash before updating.
- This prevents unnecessary updates and ensures the correct message is targeted for deletion.