### PR TITLE
Refactor DevChat installation error handling

### DIFF
--- a/src/panel/statusBarViewBase.ts
+++ b/src/panel/statusBarViewBase.ts
@@ -92,18 +92,16 @@ export async function dependencyCheck(): Promise<[string, string]> {
 		}, undefined, undefined);
 
 		// UiUtilWrapper.runTerminal('DevChat Install', `${pythonCommand} "${UiUtilWrapper.extensionPath() + "/tools/install.py"}"`);
-		if (errorInstall) {
-			devchatStatus = 'An error occurred during the installation of DevChat';
-		} else {
-			// ==> devchatCommandEnv:  /Users/admin/work/devchat-vscode/tools/devchat/bin/devchat
-			const devchatCommandEnv = installLogs.match(/devchatCommandEnv:  (.*)/)?.[1];
+		const devchatCommandEnv = installLogs.match(/devchatCommandEnv:  (.*)/)?.[1];
+		if (devchatCommandEnv) {
 			logger.channel()?.info(`devchatCommandEnv: ${devchatCommandEnv}`);
-			if (devchatCommandEnv) {
-				UiUtilWrapper.updateConfiguration('DevChat', 'DevChatPath', devchatCommandEnv);
-			}
-			
+			await UiUtilWrapper.updateConfiguration('DevChat', 'DevChatPath', devchatCommandEnv);
 			devchatStatus = 'DevChat has been installed';
+		} else {
+			logger.channel()?.info(`devchatCommandEnv: undefined`);
+			devchatStatus = 'An error occurred during the installation of DevChat';
 		}
+
 		isVersionChangeCompare = true;
 	}
 


### PR DESCRIPTION
- Removed unnecessary if-else condition for errorInstall.
- Moved devchatCommandEnv extraction outside the if-else block.
- Added condition to check if devchatCommandEnv exists before updating configuration and setting devchatStatus.
- Added else block to handle case when devchatCommandEnv is undefined.