### PR TITLE
Update API key validation and handling

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -74,8 +74,8 @@ export function registerApiKeySettingCommand(context: vscode.ExtensionContext) {
 				placeHolder: "Set OPENAI_API_KEY (or DevChat Access Key)"
 			}) ?? '';
 
-			if (!isValidApiKey(passwordInput)) {
-				UiUtilWrapper.showErrorMessage("You access key is invalid!");
+			if (passwordInput.trim() !== "" && !isValidApiKey(passwordInput)) {
+				UiUtilWrapper.showErrorMessage("Your access key is invalid!");
 				return ;
 			}
 			ApiKeyManager.writeApiKeySecret(passwordInput);

--- a/src/util/apiKey.ts
+++ b/src/util/apiKey.ts
@@ -15,7 +15,7 @@ export class ApiKeyManager {
 	}
 
 	static getKeyType(apiKey: string): string | undefined {
-		if (apiKey.startsWith("sk.")) {
+		if (apiKey.startsWith("sk-")) {
 			return "sk";
 		} else if (apiKey.startsWith("DC.")) {
 			return "DC";

--- a/test/util/apiKey.test.ts
+++ b/test/util/apiKey.test.ts
@@ -14,28 +14,28 @@ describe('ApiKeyManager', () => {
 
   describe('getApiKey', () => {
     it('should return the secret storage API key', async () => {
-      sinon.stub(UiUtilWrapper, 'secretStorageGet').resolves('sk.secret');
+      sinon.stub(UiUtilWrapper, 'secretStorageGet').resolves('sk-secret');
       sinon.stub(UiUtilWrapper, 'getConfiguration').returns(undefined);
 
       const apiKey = await ApiKeyManager.getApiKey();
-      expect(apiKey).to.equal('sk.secret');
+      expect(apiKey).to.equal('sk-secret');
     });
 
     it('should return the configuration API key', async () => {
       sinon.stub(UiUtilWrapper, 'secretStorageGet').resolves(undefined);
-      sinon.stub(UiUtilWrapper, 'getConfiguration').returns('sk.config');
+      sinon.stub(UiUtilWrapper, 'getConfiguration').returns('sk-config');
 
       const apiKey = await ApiKeyManager.getApiKey();
-      expect(apiKey).to.equal('sk.config');
+      expect(apiKey).to.equal('sk-config');
     });
 
     it('should return the environment variable API key', async () => {
       sinon.stub(UiUtilWrapper, 'secretStorageGet').resolves(undefined);
       sinon.stub(UiUtilWrapper, 'getConfiguration').returns(undefined);
-      process.env.OPENAI_API_KEY = 'sk.env';
+      process.env.OPENAI_API_KEY = 'sk-env';
 
       const apiKey = await ApiKeyManager.getApiKey();
-      expect(apiKey).to.equal('sk.env');
+      expect(apiKey).to.equal('sk-env');
     });
   });
 
@@ -43,7 +43,7 @@ describe('ApiKeyManager', () => {
     it('should return the configuration endpoint', () => {
       sinon.stub(UiUtilWrapper, 'getConfiguration').returns('https://config-endpoint.com');
 
-      const endPoint = ApiKeyManager.getEndPoint('sk.key');
+      const endPoint = ApiKeyManager.getEndPoint('sk-key');
       expect(endPoint).to.equal('https://config-endpoint.com');
     });
 
@@ -51,7 +51,7 @@ describe('ApiKeyManager', () => {
       sinon.stub(UiUtilWrapper, 'getConfiguration').returns(undefined);
       process.env.OPENAI_API_BASE = 'https://env-endpoint.com';
 
-      const endPoint = ApiKeyManager.getEndPoint('sk.key');
+      const endPoint = ApiKeyManager.getEndPoint('sk-key');
       expect(endPoint).to.equal('https://env-endpoint.com');
     });
 
@@ -65,7 +65,7 @@ describe('ApiKeyManager', () => {
 
   describe('getKeyType', () => {
     it('should return "sk" for sk keys', () => {
-      const keyType = ApiKeyManager.getKeyType('sk.key');
+      const keyType = ApiKeyManager.getKeyType('sk-key');
       expect(keyType).to.equal('sk');
     });
 
@@ -84,8 +84,8 @@ describe('ApiKeyManager', () => {
     it('should store the API key in secret storage', async () => {
       const storeSecretStub = sinon.stub(UiUtilWrapper, 'storeSecret').resolves();
 
-      await ApiKeyManager.writeApiKeySecret('sk.secret');
-      expect(storeSecretStub.calledWith('devchat_OPENAI_API_KEY', 'sk.secret')).to.be.true;
+      await ApiKeyManager.writeApiKeySecret('sk-secret');
+      expect(storeSecretStub.calledWith('devchat_OPENAI_API_KEY', 'sk-secret')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
- Modified the API key validation logic to check for non-empty strings before validating.
- Updated the API key prefix from 'sk.' to 'sk-' in the ApiKeyManager and corresponding tests.
- Adjusted the test cases to reflect the new API key format.