### PR TITLE
Add hasLoadTopics flag and loadTopics() call

### DIFF
--- a/src/panel/statusBarViewBase.ts
+++ b/src/panel/statusBarViewBase.ts
@@ -25,6 +25,8 @@ let apiKeyStatus = '';
 let preDevchatStatus = '';
 let preApiKeyStatus = '';
 
+let hasLoadTopics: boolean = false;
+
 export async function dependencyCheck(): Promise<[string, string]> {
 	// there are some different status of devchat:
 	// 0. not checked
@@ -96,6 +98,15 @@ export async function dependencyCheck(): Promise<[string, string]> {
 
 	const devchatPackageStatus = await getDevChatStatus();
 	const apiAccessKeyStatus = await getApiKeyStatus();
+
+	if (devchatPackageStatus === 'has statisfied the dependency' || devchatPackageStatus === 'DevChat has been installed') {
+		if (apiAccessKeyStatus === 'has valid access key') {
+			if (!hasLoadTopics) {
+				TopicManager.getInstance().loadTopics();
+			}
+			hasLoadTopics = true;
+		}
+	}
 
 	if (devchatPackageStatus !== preDevchatStatus) {
 		logger.channel()?.info(`devchat status: ${devchatPackageStatus}`);


### PR DESCRIPTION
- Added a new boolean flag 'hasLoadTopics' to track whether topics have been loaded.
- If the devchat package has been installed and the API access key is valid, the 'loadTopics()' method of the TopicManager class is called.
- This ensures that topics are only loaded once when the dependencies are satisfied.