### PR TITLE
Refine response text parsing in getUndefinedSymbols

### DIFF
--- a/src/context/contextRefDefs.ts
+++ b/src/context/contextRefDefs.ts
@@ -54,11 +54,12 @@ async function getUndefinedSymbols(content: string): Promise<string[]> {
         return [];
     }
 
-    let responseText = chatResponse.response;
+    let responseText = chatResponse.response.trim();
     let symbols: string[];
 
-    if (responseText.startsWith("```json") && responseText.endsWith("```")) {
-        responseText = responseText.substring(7, responseText.length - 3);
+    if (responseText.startsWith("```") && responseText.endsWith("```")) {
+		const index = responseText.indexOf('[');
+        responseText = responseText.substring(index, responseText.length - 3);
         try {
             symbols = JSON.parse(responseText);
         } catch (error) {


### PR DESCRIPTION
- Updated the response text trimming logic in getUndefinedSymbols function in contextRefDefs.ts.
- Now the function correctly extracts the JSON content from the response text.