### PR TITLE
Add settings link to DevChat

### DIFF
--- a/src/views/components/MessageMarkdown/index.tsx
+++ b/src/views/components/MessageMarkdown/index.tsx
@@ -117,6 +117,9 @@ Generate a professionally written and formatted release note in markdown with th
                     }),
                 ]);
                 break;
+            case "#settings":
+                messageUtil.sendMessage({ command: 'doCommand', content: ['workbench.action.openSettings', 'DevChat'] });
+                break;
         }
         chat.goScrollBottom();
     };
@@ -189,7 +192,8 @@ Generate a professionally written and formatted release note in markdown with th
                     "#commit_message",
                     "#release_note",
                     "#ask_code",
-                    "#extension"].filter((item) => item === href);
+                    "#extension",
+                    "#settings"].filter((item) => item === href);
                 return customAnchors.length > 0
                     ? <Anchor href={href} onClick={() => {
                         handleExplain(href);

--- a/src/views/stores/ChatStore.ts
+++ b/src/views/stores/ChatStore.ts
@@ -98,7 +98,7 @@ To get started, here are some of the things that I can do for you:
 
 ${self.features['ask-code'] ? '[/ask-code: ask me questions about your codebase](#ask_code)' : ''}
 
-<button value="settings">Settings</button>`;
+You can configure DevChat from [Settings](#settings).`;
 
             self.messages.push(
                 Message.create({


### PR DESCRIPTION
- Added a case for "#settings" in MessageMarkdown component to handle settings command.
- Included "#settings" in the list of custom anchors.
- Replaced the settings button in ChatStore with a link to settings.