### PR TITLE
Add ScrollArea to InputContexts component

### DIFF
--- a/src/views/components/InputMessage/InputContexts.tsx
+++ b/src/views/components/InputMessage/InputContexts.tsx
@@ -81,13 +81,15 @@ const InputContexts = observer(() => {
                             </ActionIcon>
                         </Box>
                         <Accordion.Panel>
-                            {
-                                content
-                                    ? <pre style={{ overflowWrap: 'normal', fontSize: 'var(--vscode-editor-font-size)', margin: 0 }}>{content}</pre>
-                                    : <Center>
-                                        <Text c='gray.3'>No content</Text>
-                                    </Center>
-                            }
+                            <ScrollArea type="auto">
+                                {
+                                    content
+                                        ? <pre style={{ overflowWrap: 'normal', fontSize: 'var(--vscode-editor-font-size)', margin: 0 }}>{content}</pre>
+                                        : <Center>
+                                            <Text c='gray.3'>No content</Text>
+                                        </Center>
+                                }
+                            </ScrollArea>
                         </Accordion.Panel>
                     </Accordion.Item>
                 );


### PR DESCRIPTION
- Wrapped the content of the Accordion.Panel in a ScrollArea component.
- This change allows the content to be scrollable when it exceeds the panel's height.