### PR TITLE
Add getUserAccessKey handler and related functionality

### DIFF
--- a/src/handler/loadHandlers.ts
+++ b/src/handler/loadHandlers.ts
@@ -18,6 +18,7 @@ import { applyAction } from './applyAction';
 import { doCommand } from './doCommand';
 import { getSetting, updateSetting } from './updateConfig';
 import { featureToggle, featureToggles } from './featureToggle';
+import { getUserAccessKey } from './userAccessKey';
 
 
 // According to the context menu selected by the user, add the corresponding context file
@@ -89,3 +90,5 @@ messageHandler.registerHandler('updateSetting', updateSetting);
 messageHandler.registerHandler('getSetting', getSetting);
 messageHandler.registerHandler('featureToggle', featureToggle);
 messageHandler.registerHandler('featureToggles', featureToggles);
+
+messageHandler.registerHandler('getUserAccessKey', getUserAccessKey);

--- a/src/handler/userAccessKey.ts
+++ b/src/handler/userAccessKey.ts
@@ -1,0 +1,33 @@
+/*
+Update config
+*/
+
+import * as vscode from 'vscode';
+import { regInMessage, regOutMessage } from '../util/reg_messages';
+import { UiUtilWrapper } from '../util/uiUtil';
+import { MessageHandler } from './messageHandler';
+import { ApiKeyManager } from '../util/apiKey';
+
+regInMessage({command: 'getUserAccessKey', key1: "DevChat", key2: "OpenAI"});
+regOutMessage({command: 'getUserAccessKey', accessKey: "DC.xxx", keyType: "DevChat", endPoint: "https://xxx"});
+export async function getUserAccessKey(message: any, panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {
+	const workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
+		let openaiApiKey = await ApiKeyManager.getApiKey();
+		if (!openaiApiKey) {
+			MessageHandler.sendMessage(panel, {"command": "getUserAccessKey", "accessKey": "", "keyType": "", "endPoint": ""});
+			return;
+		}
+
+		let keyType = ApiKeyManager.getKeyType(openaiApiKey!);
+		if (keyType === "DC") {
+			keyType = "DevChat";
+		} else if (keyType === "sk") {
+			keyType = "OpenAI";
+		}
+
+		let openAiApiBase = ApiKeyManager.getEndPoint(openaiApiKey);
+		if (!openAiApiBase) {
+			openAiApiBase = "";
+		}
+		MessageHandler.sendMessage(panel, {"command": "getUserAccessKey", "accessKey": openaiApiKey, "keyType": keyType, "endPoint": openAiApiBase});
+}


### PR DESCRIPTION
- Imported getUserAccessKey in loadHandlers.ts and registered it as a message handler.
- Created a new file userAccessKey.ts to handle getting user access keys.
- The getUserAccessKey function retrieves the API key, determines its type (DevChat or OpenAI), and gets the endpoint.
- If no API key is found, a message is sent with empty values.