### PR TITLE
Implement various enhancements and fixes across multiple files

### DIFF
--- a/src/action/runVSCodeCommand.ts
+++ b/src/action/runVSCodeCommand.ts
@@ -42,6 +42,9 @@ export class RunVSCodeCommandAction implements Action {
     async handlerAction(args: {[key: string]: any}): Promise<CommandResult> {
         try {
             const commandArgs = args.args ? args.args.split(',') : [];
+			if (args.command === 'vscode.open' && commandArgs.length > 0) {
+				commandArgs[0] = vscode.Uri.file(commandArgs[0]);
+			}
             const result = await vscode.commands.executeCommand(args.command, ...commandArgs);
             return {exitCode: 0, stdout: JSON.stringify(result), stderr: ""};
         } catch (error) {

--- a/src/handler/sendMessage.ts
+++ b/src/handler/sendMessage.ts
@@ -121,7 +121,19 @@ regOutMessage({ command: 'receiveMessagePartial', text: 'xxxx', user: 'xxx', dat
 //     { command: 'receiveMessage', text: 'xxxx', hash: 'xxx', user: 'xxx', date: 'xxx'}
 //     { command: 'receiveMessagePartial', text: 'xxxx', user: 'xxx', date: 'xxx'}
 export async function sendMessage(message: any, panel: vscode.WebviewPanel|vscode.WebviewView, function_name: string|undefined = undefined): Promise<void> {
-    _lastMessage = [message, function_name];
+    if (function_name !== undefined && function_name !== "") {
+		const messageText = _lastMessage[0].text.trim();
+		if (messageText[0] === '/' && message.text[0] !== '/') {
+			const indexS = messageText.indexOf(' ');
+			let preCommand = messageText;
+			if (indexS !== -1) {
+				preCommand = messageText.substring(0, indexS);
+			}
+
+			message.text = preCommand + ' ' + message.text;
+		}
+	}
+	_lastMessage = [message, function_name];
 
     // Add a new field to store the names of temporary files
     let tempFiles: string[] = [];

--- a/src/util/commonUtil.ts
+++ b/src/util/commonUtil.ts
@@ -56,7 +56,21 @@ export class CommandRun {
 	public async spawnAsync(command: string, args: string[], options: object, onData: ((data: string) => void) | undefined, onError: ((data: string) => void) | undefined, onOutputFile: ((command: string, stdout: string, stderr: string) => string) | undefined, outputFile: string | undefined): Promise<CommandResult> {
 		return new Promise((resolve, reject) => {
 			logger.channel()?.info(`Running command: ${command} ${args.join(' ')}`);
-			this.childProcess = spawn(command, args, options);
+			const argsNew: string[] = args.map((arg) => {
+				if (arg.trim()[0] === '$') {
+					// get rest string except '$'
+					const restStr = arg.trim().slice(1);
+					if (process.env[restStr]) {
+						return process.env[restStr]!;
+					} else {
+						return arg;
+					}
+				} else {
+					return arg;
+				}
+			});
+
+			this.childProcess = spawn(command, argsNew, options);
 
 			let stdout = '';
 			let stderr = '';

--- a/workflows/auto_command/action/new_file/handler.py
+++ b/workflows/auto_command/action/new_file/handler.py
@@ -17,6 +17,9 @@ def create_new_file(content_file, new_file):
     try:
         if os.path.exists(new_file):
             os.remove(new_file)
+        # Create the parent directories for the new file if they don't exist.
+        os.makedirs(os.path.dirname(new_file), exist_ok=True)
+        
         shutil.move(content_file, new_file)
     except Exception as e:
         sys.stderr.write(f"Error: {str(e)}\n")


### PR DESCRIPTION
- In runVSCodeCommand.ts, added a condition to convert the first argument to a Uri if the command is 'vscode.open'.
- In sendMessage.ts, added logic to prepend the previous command to the message text if the message starts with '/'.
- In commonUtil.ts, modified the spawnAsync function to replace arguments starting with '$' with their corresponding environment variable values.
- In handler.py, added code to create parent directories for a new file if they don't exist.