### PR TITLE
Change conda installation directory from .devchat to .chat

### DIFF
--- a/src/util/python_installer/conda_install.ts
+++ b/src/util/python_installer/conda_install.ts
@@ -36,7 +36,7 @@ async function isCondaInstalled(): Promise<string> {
   // whether ~/.devchat/conda/bin/conda exists
   const os = process.platform;
   const userHome = os === 'win32' ? fs.realpathSync(process.env.USERPROFILE || '') : process.env.HOME;
-  const pathToConda = `${userHome}/.devchat/conda`;
+  const pathToConda = `${userHome}/.chat/conda`;
   const condaPath = os === 'win32' ? `${pathToConda}/Scripts/conda.exe` : `${pathToConda}/bin/conda`;
   logger.channel()?.info(`checking conda path: ${condaPath}`); 
   const isCondaPathExists = fs.existsSync(condaPath);
@@ -82,7 +82,7 @@ async function installCondaByInstallFile(installFileUrl: string) : Promise<strin
     
     // Set the installation directory for conda
     const userHome = os === 'win32' ? fs.realpathSync(process.env.USERPROFILE || '') : process.env.HOME;
-	const pathToConda = `${userHome}/.devchat/conda`;
+	const pathToConda = `${userHome}/.chat/conda`;
 	// if pathToConda has exist, remove it first
 	try {
 		if (fs.existsSync(pathToConda)) {

--- a/src/util/python_installer/python_install.ts
+++ b/src/util/python_installer/python_install.ts
@@ -107,7 +107,7 @@ export async function installPythonMicromamba(mambaCommandPath: string, envName:
 			userHome = 'E:/Program Files';
 		}
 	}
-    const pathToMamba = `${userHome}/.devchat/mamba`;
+    const pathToMamba = `${userHome}/.chat/mamba`;
 
 	const envPath = path.resolve(pathToMamba, 'envs', envName);
 	let pythonPath;

--- a/src/util/python_installer/readme.md
+++ b/src/util/python_installer/readme.md
@@ -6,7 +6,7 @@ pyenv is also a python version manager, but it always download source of python,
 conda is a package manager, it can download binary of python, and install packages.
 
 # Where to install?
-Install conda to $USER_PROFILE/.devchat
+Install conda to $USER_PROFILE/.chat
 
-Python will install inside $USER_PROFILE/.devchat/conda.
+Python will install inside $USER_PROFILE/.chat/conda.
 


### PR DESCRIPTION
- Updated the conda installation directory from .devchat to .chat in conda_install.ts.
- Updated the mamba installation directory from .devchat to .chat in python_install.ts.
- Updated the installation directory in the readme.md file.