### PR TITLE
Remove line popping items from messages array in ChatStore

### DIFF
--- a/src/views/stores/ChatStore.ts
+++ b/src/views/stores/ChatStore.ts
@@ -273,7 +273,6 @@ The process might take a few minutes, depending on your network connection. In t
                 self.hasDone = false;
                 self.errorMessage = '';
                 self.currentMessage = '';
-                self.messages.pop();
                 messageUtil.sendMessage({
                     command: 'regeneration'
                 });


### PR DESCRIPTION
- Removed the self.messages.pop() call in the process of sending a 'regeneration' command.