### PR TITLE
Reduce frequency of DevChat notifications on startup

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -374,7 +374,7 @@ export function registerInstallCommandsPython(context: vscode.ExtensionContext) 
 		}
 		
 		UiUtilWrapper.updateConfiguration("DevChat", "PythonForCommands", pythonCommand.trim());
-		vscode.window.showInformationMessage(`All slash Commands are ready to use! Please input / to try workflow commands!`);
+		// vscode.window.showInformationMessage(`All slash Commands are ready to use! Please input / to try workflow commands!`);
 	});
 
 	context.subscriptions.push(disposable);

--- a/src/util/progressBar.ts
+++ b/src/util/progressBar.ts
@@ -19,7 +19,7 @@ export class ProgressBar {
             return new Promise<void>((resolve) => {
                 const timer = setInterval(() => {
 					if (this.finish === true && this.error === "") {
-						vscode.window.showInformationMessage(`${this.message}`);
+						// vscode.window.showInformationMessage(`${this.message}`);
 						resolve();
 						clearInterval(timer);
 					} else if (this.finish === true && this.error !== "") {


### PR DESCRIPTION
This pull request addresses the issue reported in [#155](https://github.com/devchat-ai/devchat/issues/155), where users were experiencing an excessive number of notifications every time they opened VS Code or a project.

Changes introduced:
- The informational messages for command readiness are no longer displayed during every startup.
- A new periodic check has been implemented to monitor the status of DevChat commands.
- The DevChat status bar item tooltip will now conditionally display based on specific events rather than always showing.

These changes aim to improve user experience by only showing notifications that are relevant to users' activities, conforming to the request of only showing them upon installation, updating, or when issues occur.

Closes devchat-ai/devchat#155.