### PR TITLE
Fix Sidebar Activation and DevChat Command Execution Issues

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -383,6 +383,14 @@ export function registerInstallCommandsPython(context: vscode.ExtensionContext) 
 export function registerDevChatChatCommand(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand('DevChat.Chat', async (message: string) => {
 		ensureChatPanel(context);
+		if (!ExtensionContextHolder.provider?.view()) {
+			// wait 2 seconds
+			await new Promise((resolve, reject) => {
+				setTimeout(() => {
+					resolve(true);
+				}, 2000);
+			});
+		}
 		chatWithDevChat(ExtensionContextHolder.provider?.view()!, message);
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,7 +257,6 @@ async function activate(context: vscode.ExtensionContext) {
 	await updateInvalidSettings();
 
     regLanguageContext();
-	registerCodeLensProvider(context);
 
     regDevChatView(context);
     regTopicView(context);
@@ -284,6 +283,7 @@ async function activate(context: vscode.ExtensionContext) {
 
     regPythonPathCommand(context);
 	registerDevChatChatCommand(context);
+	registerCodeLensProvider(context);
 
 	startRpcServer();
 }


### PR DESCRIPTION
This pull request addresses two significant issues experienced by users:

- The sidebar not activating when clicking 'Add Tests', requiring a double-click to initiate the process
- An error message displaying 'Actual command not found, wanted to execute DevChat.Chat /25' when attempting certain operations

The updates include a delay to ensure the sidebar is properly activated on the first click and a reordering of the CodeLens provider registration to resolve command execution errors.

These fixes should enhance user experience with more responsive interactions and reduce the occurrence of confusing error messages.

Resolves devchat-ai/devchat#182