### PR TITLE
Implement get_symbol_defines_in_selected_code Functionality

### DIFF
--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -123,7 +123,7 @@ const functionRegistry: any = {
 				return [];
 			}
 
-			const symbols = convertSymbolsToPlainObjects(symbols2);
+			const symbols = convertSymbolsToPlainObjects(documentSymbols);
 			return symbols;
 		}
 	},

--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -18,6 +18,7 @@ import {
 import { findReferences } from "./lsp_bridge/feature/find-refs";
 import { convertSymbolsToPlainObjects, executeProviderCommand } from './lsp/lsp';
 import { applyCodeWithDiff } from '../handler/diffHandler';
+import { getSymbolDefines } from '../context/contextRefDefs';
 
 
 const functionRegistry: any = {
@@ -122,7 +123,7 @@ const functionRegistry: any = {
 				return [];
 			}
 
-			const symbols = convertSymbolsToPlainObjects(documentSymbols);
+			const symbols = convertSymbolsToPlainObjects(symbols2);
 			return symbols;
 		}
 	},
@@ -264,6 +265,19 @@ const functionRegistry: any = {
 			}
 
 			return pythonCommand.trim();
+		}
+	},
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	"/get_symbol_defines_in_selected_code": {
+		"keys": [],
+		"handler": async () => {
+			// find needed symbol defines in current editor document
+			// return value is a list of symbol defines
+			// each define has three fileds: 
+			// path: file path contain that symbol define
+			// startLine: start line in that file
+			// content: source code for symbol define
+			return getSymbolDefines();
 		}
 	}
 };


### PR DESCRIPTION
This pull request introduces a new function `get_symbol_defines_in_selected_code` as part of the `add_tests` workflow. This function is designed to enhance the workflow by allowing better symbol definition handling within selected code segments. This is particularly useful for improving test coverage and accuracy.

No related issue was referenced for this change.