### PR TITLE
Fix document_symbols substructure information in ide_services

### DIFF
--- a/src/ide_services/lsp/lsp.ts
+++ b/src/ide_services/lsp/lsp.ts
@@ -91,7 +91,7 @@ const convertSymbolInformation = (symbol: vscode.SymbolInformation): any => {
 // Generic function to convert an array of DocumentSymbol or SymbolInformation to a plain object array
 export const convertSymbolsToPlainObjects = (symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[]): any[] => {
     return symbols.map(symbol => {
-        if (symbol instanceof vscode.DocumentSymbol) {
+		if (symbol.children) {
             // Handle DocumentSymbol with recursive conversion
             return convertDocumentSymbol(symbol);
         } else {


### PR DESCRIPTION
This pull request addresses the bug reported in issue #233 where the `document_symbols` interface in `ide_services` was not returning the expected substructure information.

The interface now correctly processes the `DocumentSymbol` substructure by referencing `symbol.children` instead of using an instance type check. The changes ensure that the complete information is returned by the `document_symbols` interface.

Fixes: devchat-ai/devchat#233