### PR TITLE
Feature: Command Recommendations with Directory Awareness on Welcome Page

### DIFF
--- a/src/handler/workflowCommandHandler.ts
+++ b/src/handler/workflowCommandHandler.ts
@@ -9,6 +9,7 @@ export interface Command {
 	name: string;
 	pattern: string;
 	description: string;
+	path: string;
 	args: number;
 	handler: (commandName: string, userInput: string) => Promise<string>;
 }
@@ -24,6 +25,7 @@ async function getCommandListByDevChatRun(includeHide: boolean = false): Promise
 			name: command.name,
 			pattern: command.name,
 			description: command.description,
+			path: command.path,
 			args: 0,
 			handler: async (commandName: string, userInput: string) => { return ''; }
 		};

--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -41,6 +41,7 @@ export interface LogEntry {
 export interface CommandEntry {
 	name: string;
 	description: string;
+	path: string;
 }
 
 export interface TopicEntry {


### PR DESCRIPTION
This pull request introduces the implementation for command recommendations with directory awareness on the welcome page, fulfilling the requirements of our feature request. With these changes, the welcome page will now recommend commands from the 'org' and 'sys' directories. Additionally, if a command lacks a sufficient description, the system will attempt to display the contents of the command's directory's README.md file. An error message will be shown if no README.md is available or if there is any other issue with the command input.

Changes Made:
- Added a 'path' property to the command struct for directory context.
- Updated command object creation to include the 'path' property when listing commands in the devchat run listing.
- Modified the CommandEntry interface in devchat tool wrapper to include 'path'.
- Updated subproject commit references to ensure compatibility.

These enhancements aim to improve the user experience by making command information more accessible from the welcome page, aiding new users in learning important commands quickly.

Closes https://github.com/devchat-ai/devchat/issues/236