### PR TITLE
Refactor UI for Unified Topic Interaction on Small Screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -548,39 +548,10 @@
 					"type": "webview",
 					"id": "devchat-view",
 					"name": "DevChat"
-				},
-				{
-					"type": "tree",
-					"id": "devchat-topicview",
-					"name": "DevChat-Topic"
 				}
 			]
 		},
 		"commands": [
-			{
-				"command": "devchat-topicview.reloadTopic",
-				"title": "Reload Topics",
-				"icon": "$(refresh)"
-			},
-			{
-				"command": "devchat-topicview.selectTopic",
-				"title": "Select Topic",
-				"icon": "$(add)"
-			},
-			{
-				"command": "devchat-topicview.addTopic",
-				"title": "Add Topic",
-				"icon": "$(add)"
-			},
-			{
-				"command": "devchat-topicview.deleteSelectedTopic",
-				"title": "Delete Selected Topic",
-				"icon": "$(trash)"
-			},
-			{
-				"command": "devchat-topicview.deleteTopic",
-				"title": "Delete topic"
-			},
 			{
 				"command": "devchat.applyDiffResult",
 				"title": "Apply Diff",
@@ -655,30 +626,6 @@
 			}
 		],
 		"menus": {
-			"view/item/context": [
-				{
-					"command": "devchat-topicview.deleteTopic",
-					"when": "view == devchat-topicview",
-					"group": "1_modification"
-				}
-			],
-			"view/title": [
-				{
-					"command": "devchat-topicview.addTopic",
-					"when": "view == devchat-topicview",
-					"group": "navigation"
-				},
-				{
-					"command": "devchat-topicview.deleteSelectedTopic",
-					"when": "view == devchat-topicview",
-					"group": "navigation"
-				},
-				{
-					"command": "devchat-topicview.reloadTopic",
-					"when": "view == devchat-topicview",
-					"group": "navigation"
-				}
-			],
 			"editor/title": [
 				{
 					"command": "devchat.applyDiffResult",
@@ -687,26 +634,6 @@
 				}
 			],
 			"commandPalette": [
-				{
-					"command": "devchat-topicview.reloadTopic",
-					"when": "false"
-				},
-				{
-					"command": "devchat-topicview.selectTopic",
-					"when": "false"
-				},
-				{
-					"command": "devchat-topicview.addTopic",
-					"when": "false"
-				},
-				{
-					"command": "devchat-topicview.deleteSelectedTopic",
-					"when": "false"
-				},
-				{
-					"command": "devchat-topicview.deleteTopic",
-					"when": "false"
-				},
 				{
 					"command": "devchat.applyDiffResult",
 					"when": "false"

--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -162,67 +162,6 @@ export function registerStatusBarItemClickCommand(context: vscode.ExtensionConte
 	);
 }
 
-const topicDeleteCallback = async (item: TopicTreeItem) => {
-	const confirm = 'Delete';
-	const label = typeof item.label === 'string' ? item.label : item.label!.label;
-	const truncatedLabel = label.substring(0, 20) + (label.length > 20 ? '...' : '');
-	const result = await vscode.window.showWarningMessage(
-		`Are you sure you want to delete the topic "${truncatedLabel}"?`,
-		{ modal: true },
-		confirm
-	);
-
-	if (result === confirm) {
-		TopicManager.getInstance().deleteTopic(item.id);
-	}
-};
-
-
-export function regTopicDeleteCommand(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('devchat-topicview.deleteTopic', topicDeleteCallback)
-	);
-}
-
-export function regAddTopicCommand(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('devchat-topicview.addTopic', () => {
-			const topic = TopicManager.getInstance().createTopic();
-			TopicManager.getInstance().setCurrentTopic(topic.topicId);
-		})
-	);
-}
-
-export function regDeleteSelectTopicCommand(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('devchat-topicview.deleteSelectedTopic', () => {
-			const selectedItem = TopicTreeDataProvider.getInstance().selectedItem;
-			if (selectedItem) {
-				topicDeleteCallback(selectedItem);
-			} else {
-				vscode.window.showErrorMessage('No item selected');
-			}
-		})
-	);
-}
-
-export function regSelectTopicCommand(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('devchat-topicview.selectTopic', (item: TopicTreeItem) => {
-			TopicTreeDataProvider.getInstance().setSelectedItem(item);
-			TopicManager.getInstance().setCurrentTopic(item.id);
-		})
-	);
-}
-
-export function regReloadTopicCommand(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.commands.registerCommand('devchat-topicview.reloadTopic', async () => {
-			TopicManager.getInstance().loadTopics();
-		})
-	);
-}
-
 export function regPythonPathCommand(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('devchat.PythonPath', async () => {

--- a/src/contributes/views.ts
+++ b/src/contributes/views.ts
@@ -12,10 +12,3 @@ export function regDevChatView(context: vscode.ExtensionContext) {
 		})
 	);
 }
-
-export function regTopicView(context: vscode.ExtensionContext) {
-	const yourTreeView = vscode.window.createTreeView('devchat-topicview', {
-		treeDataProvider: TopicTreeDataProvider.getInstance(),
-	});
-	context.subscriptions.push(yourTreeView);
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,11 +6,6 @@ import {
     registerAskForCodeCommand,
     registerAskForFileCommand,
     registerAccessKeySettingCommand,
-    regTopicDeleteCommand,
-    regAddTopicCommand,
-    regDeleteSelectTopicCommand,
-    regSelectTopicCommand,
-    regReloadTopicCommand,
     regApplyDiffResultCommand,
     registerStatusBarItemClickCommand,
     regPythonPathCommand,
@@ -21,7 +16,7 @@ import {
 	registerHandleUri,
 } from './contributes/commands';
 import { regLanguageContext } from './contributes/context';
-import { regDevChatView, regTopicView } from './contributes/views';
+import { regDevChatView } from './contributes/views';
 
 import { ExtensionContextHolder } from './util/extensionContext';
 import { logger } from './util/logger';
@@ -294,7 +289,6 @@ async function activate(context: vscode.ExtensionContext) {
     regLanguageContext();
 
     regDevChatView(context);
-    regTopicView(context);
 
     registerAccessKeySettingCommand(context);
     registerOpenChatPanelCommand(context);
@@ -309,11 +303,6 @@ async function activate(context: vscode.ExtensionContext) {
 
     createStatusBarItem(context);
 
-    regTopicDeleteCommand(context);
-    regAddTopicCommand(context);
-    regDeleteSelectTopicCommand(context);
-    regSelectTopicCommand(context);
-    regReloadTopicCommand(context);
     regApplyDiffResultCommand(context);
 
     regPythonPathCommand(context);

--- a/src/handler/handlerRegister.ts
+++ b/src/handler/handlerRegister.ts
@@ -16,6 +16,7 @@ import { featureToggle, getFeatureToggles } from './featureToggleHandler';
 import { getUserAccessKey } from './accessKeyHandler';
 import { getValidLlmModelList } from './llmModelHandler';
 import { readFile, writeFile } from './fileHandler';
+import { getTopics, deleteTopic } from './topicHandler';
 
 
 // According to the context menu selected by the user, add the corresponding context file
@@ -82,4 +83,7 @@ messageHandler.registerHandler('userInput', userInput);
 
 messageHandler.registerHandler('readFile', readFile);
 messageHandler.registerHandler('writeFile', writeFile);
+
+messageHandler.registerHandler('getTopics', getTopics);
+messageHandler.registerHandler('deleteTopic', deleteTopic);
 

--- a/src/handler/historyMessagesBase.ts
+++ b/src/handler/historyMessagesBase.ts
@@ -155,22 +155,13 @@ export async function apiKeyInvalidMessage(): Promise<LoadHistoryMessages | unde
 	}
 }
 
-export async function historyMessagesBase(): Promise<LoadHistoryMessages | undefined> {
-	const topicId = TopicManager.getInstance().currentTopicId;
+export async function historyMessagesBase(topicId: string): Promise<LoadHistoryMessages | undefined> {
 	const logEntriesFlat = await loadTopicHistoryLogs(topicId);
 	if (!logEntriesFlat) {
 		return undefined;
 	}
 
-	if (topicId !== TopicManager.getInstance().currentTopicId) {
-		return undefined;
-	}
-	updateCurrentMessageHistory(topicId!, logEntriesFlat);
-
-	// const apiKeyMessage = await apiKeyInvalidMessage();
-	// if (apiKeyMessage !== undefined) {
-	// 	return apiKeyMessage;
-	// }
+	updateCurrentMessageHistory(topicId, logEntriesFlat);
 
 	return {
 		command: 'loadHistoryMessages',

--- a/src/handler/historyMessagesHandler.ts
+++ b/src/handler/historyMessagesHandler.ts
@@ -8,19 +8,17 @@ import { UiUtilWrapper } from '../util/uiUtil';
 
 
 
-regInMessage({command: 'historyMessages', page: 0});
+regInMessage({command: 'historyMessages', topicId: '', page: 0});
 regOutMessage({command: 'loadHistoryMessages', entries: [{hash: '',user: '',date: '',request: '',response: '',context: [{content: '',role: ''}]}]});
-export async function getHistoryMessages(message: {command: string, page: number}, panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {
+export async function getHistoryMessages(message: {command: string, topicId: string, page: number}, panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {
 	// if history message has load, send it to webview
 	const maxCount = Number(UiUtilWrapper.getConfiguration('DevChat', 'maxLogCount'));
 	const skip = maxCount * (message.page ? message.page : 0);
+	const topicId = message.topicId;
 
-	if (messageHistory.getTopic() !== TopicManager.getInstance().currentTopicId) {
-		const historyMessageAll = await historyMessagesBase();
-		if (!historyMessageAll?.entries.length || historyMessageAll?.entries.length < maxCount) {
-			MessageHandler.sendMessage(panel, historyMessageAll!);
-			return;
-		}
+	const historyMessageAll = await historyMessagesBase(topicId);
+	if (!historyMessageAll?.entries.length || historyMessageAll?.entries.length < maxCount) {
+		MessageHandler.sendMessage(panel, historyMessageAll!);
 	}
 
 	const historyMessage = loadTopicHistoryFromCurrentMessageHistory(skip, maxCount);

--- a/src/handler/sendMessageBase.ts
+++ b/src/handler/sendMessageBase.ts
@@ -6,57 +6,6 @@ import { assertValue } from '../util/check';
 
 
 /**
- * Class to handle topic updates.
- */
-export class TopicUpdateHandler {
-	/**
-	 * Flag to indicate if the topic is being updated from the webview.
-	 */
-	private static isTopicUpdatingFromWebview: boolean = false;
-
-	/**
-	 * Checks if the topic change was triggered by the webview.
-	 * 
-	 * @returns {boolean} - Returns true if the topic change was triggered by the webview, false otherwise.
-	 */
-	public static isTopicChangeTriggeredByWebview(): boolean {
-		return TopicUpdateHandler.isTopicUpdatingFromWebview;
-	}
-
-	/**
-	 * Processes the topic change after a chat.
-	 * 
-	 * @param {string | undefined} parentHash - The hash of the parent message, if any.
-	 * @param {any} message - The message object.
-	 * @param {ChatResponse} chatResponse - The chat response object.
-	 * @returns {Promise<void>} - A Promise that resolves when the topic change has been processed.
-	 */
-	public static async processTopicChangeAfterChat(parentHash:string | undefined, message: any, chatResponse: ChatResponse): Promise<void> {
-		TopicUpdateHandler.isTopicUpdatingFromWebview = true;
-		try {
-			if (!chatResponse.isError) {
-				let topicId = TopicManager.getInstance().currentTopicId;
-				if (!topicId) {
-					// create new topic
-					const topic = TopicManager.getInstance().createTopic();
-					topicId = topic.topicId;
-				}
-
-				TopicManager.getInstance().updateTopic(
-					topicId!,
-					chatResponse['prompt-hash'],
-					parseDateStringToTimestamp(chatResponse.date),
-					message.text,
-					chatResponse.response
-				);
-			}
-		} finally {
-			TopicUpdateHandler.isTopicUpdatingFromWebview = false;
-		}
-	}
-}
-
-/**
  * Class to handle user interaction stop events.
  */
 class UserStopHandler {
@@ -232,7 +181,6 @@ export async function sendMessageBase(message: any, handlePartialData: (data: { 
 		assertValue(UserStopHandler.isUserInteractionStopped(), "User Stopped");
 		
 		await addMessageToHistory(message, chatResponse, message.parent_hash);
-		await TopicUpdateHandler.processTopicChangeAfterChat(message.parent_hash, message, chatResponse);
 		
 		return {
 			command: 'receiveMessage',

--- a/src/handler/topicHandler.ts
+++ b/src/handler/topicHandler.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { TopicManager } from '../topic/topicManager';
+import { regInMessage, regOutMessage } from '../util/reg_messages';
+import { MessageHandler } from './messageHandler';
+
+// 注册获取当前topic列表的命令
+regInMessage({ command: 'getTopics' });
+regOutMessage({ command: 'getTopics', topics: [] });
+export async function getTopics(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
+	await TopicManager.getInstance().loadTopics();
+    const topics = TopicManager.getInstance().getTopicList();
+    MessageHandler.sendMessage(panel, { command: 'getTopics', topics });
+}
+
+// 注册删除topic的命令
+regInMessage({ command: 'deleteTopic', topicId: '' });
+export async function deleteTopic(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
+    TopicManager.getInstance().deleteTopic(message.topicId);
+}

--- a/src/handler/topicHandler.ts
+++ b/src/handler/topicHandler.ts
@@ -2,14 +2,15 @@ import * as vscode from 'vscode';
 import { TopicManager } from '../topic/topicManager';
 import { regInMessage, regOutMessage } from '../util/reg_messages';
 import { MessageHandler } from './messageHandler';
+import DevChat, { TopicEntry } from '../toolwrapper/devchat';
 
 // 注册获取当前topic列表的命令
 regInMessage({ command: 'getTopics' });
 regOutMessage({ command: 'getTopics', topics: [] });
 export async function getTopics(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
-	await TopicManager.getInstance().loadTopics();
-    const topics = TopicManager.getInstance().getTopicList();
-    MessageHandler.sendMessage(panel, { command: 'getTopics', topics });
+    const devChat = new DevChat();
+	const topicEntries: TopicEntry[] = await devChat.topics();
+    MessageHandler.sendMessage(panel, { command: 'getTopics', topicEntries });
 }
 
 // 注册删除topic的命令

--- a/src/handler/topicHandler.ts
+++ b/src/handler/topicHandler.ts
@@ -9,7 +9,17 @@ regInMessage({ command: 'getTopics' });
 regOutMessage({ command: 'getTopics', topics: [] });
 export async function getTopics(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
     const devChat = new DevChat();
-	const topicEntries: TopicEntry[] = await devChat.topics();
+	const topicEntriesAll: TopicEntry[] = await devChat.topics();
+
+    let topicEntries: TopicEntry[] = [];
+    for (const topicEntry of topicEntriesAll) {
+        if (TopicManager.getInstance().isDeleteTopic(topicEntry.root_prompt.hash)) {
+            continue;
+        }
+        // append topicEntry to topicEntries
+        topicEntries.push(topicEntry);
+    }
+
     MessageHandler.sendMessage(panel, { command: 'getTopics', topicEntries });
 }
 

--- a/src/panel/devchatView.ts
+++ b/src/panel/devchatView.ts
@@ -9,7 +9,6 @@ import { ExtensionContextHolder } from '../util/extensionContext';
 import { TopicManager } from '../topic/topicManager';
 import { UiUtilWrapper } from '../util/uiUtil';
 import { ChatContextManager } from '../context/contextManager';
-import { TopicUpdateHandler } from '../handler/sendMessageBase';
 
 
 export class DevChatViewProvider implements vscode.WebviewViewProvider {
@@ -64,13 +63,6 @@ export class DevChatViewProvider implements vscode.WebviewViewProvider {
 			null,
 			this._context.subscriptions
 		);
-
-		TopicManager.getInstance().addOnCurrentTopicIdChangeListener((topicId) => {
-			if (topicId && TopicUpdateHandler.isTopicChangeTriggeredByWebview()) {
-				return;
-			}
-			this.reloadWebview();
-		});
 	}
 
 	private onDidChangeWorkspaceFolders(event: vscode.WorkspaceFoldersChangeEvent): void {

--- a/test/handler/sendMessageBase.test.ts
+++ b/test/handler/sendMessageBase.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import * as path from 'path';
-import { parseMessage, parseMessageAndSetOptions, TopicUpdateHandler, processChatResponse, sendMessageBase, stopDevChatBase } from '../../src/handler/sendMessageBase';
+import { parseMessage, parseMessageAndSetOptions, processChatResponse, sendMessageBase, stopDevChatBase } from '../../src/handler/sendMessageBase';
 import { ChatResponse } from '../../src/toolwrapper/devchat';
 import { UiUtilWrapper } from '../../src/util/uiUtil';
 
@@ -53,27 +53,6 @@ describe('sendMessageBase', () => {
 			expect(chatOptions.context).to.deep.equal(['path/to/context']);
 			expect(chatOptions.header).to.deep.equal(['path/to/instruction']);
 			expect(chatOptions.reference).to.deep.equal(['path/to/reference']);
-		});
-	});
-
-
-	describe('TopicUpdateHandler.processTopicChangeAfterChat', () => {
-		it('should handle topic correctly', async () => {
-			const parentHash = 'somehash';
-			const message = {
-				text: 'Hello, world!'
-			};
-			const chatResponse: ChatResponse = {
-				"finish_reason": "",
-				response: 'Hello, user!',
-				isError: false,
-				user: 'user',
-				date: '2022-01-01T00:00:00.000Z',
-				'prompt-hash': 'responsehash'
-			};
-
-			await TopicUpdateHandler.processTopicChangeAfterChat(parentHash, message, chatResponse);
-			// Check if the topic was updated correctly
 		});
 	});
 


### PR DESCRIPTION
This PR streamlines the UI experience for VSCode Topics on smaller screens. With the changes, the VSCode Topic list no longer consumes half the screen space, as it is now internally managed similarly to the JetBrains plugin.

Changes include:
- A new topicHandler to better manage getTopics and deleteTopic functions.
- Refactoring of historyMessagesHandler to work with topicId.
- Elimination of redundant UI elements for topics and consolidation of views for a more streamlined interface.
- Update of subproject commitment hash as part of the enhancement process.

These improvements align the small screen experience with user expectations and follow the suggestions provided in issue [#225](https://github.com/devchat-ai/devchat/issues/225).

Filtering deleted topics and using TopicEntry as the result for getTopics further optimize the conversation history functionalities.

Closes devchat-ai/devchat#225.