### PR TITLE
Fix for GPT-4 Exceeding max_tokens Limit Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
 							"default": 1000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
 						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 13000,
+							"description": "[optional*] Maximum text length for input to AI."
+						},
 						"presence_penalty": {
 							"type": "number",
 							"default": 0,
@@ -176,6 +181,11 @@
 							"default": 1000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
 						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 6000,
+							"description": "[optional*] Maximum text length for input to AI."
+						},
 						"presence_penalty": {
 							"type": "number",
 							"default": 0,
@@ -213,6 +223,11 @@
 							"default": 1000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
 						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 32000,
+							"description": "[optional*] Maximum text length for input to AI."
+						},
 						"presence_penalty": {
 							"type": "number",
 							"default": 0,
@@ -248,6 +263,11 @@
 							"type": "number",
 							"default": 1000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 32000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -272,8 +292,13 @@
 						},
 						"max_tokens": {
 							"type": "number",
-							"default": 4000,
+							"default": 2048,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 6000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -295,6 +320,16 @@
 							"type": "number",
 							"default": 0.5,
 							"description": "[optional*] What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic."
+						},
+						"max_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 8000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -316,6 +351,16 @@
 							"type": "number",
 							"default": 0.5,
 							"description": "[optional*] What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic."
+						},
+						"max_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 8000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -345,8 +390,13 @@
 						},
 						"max_tokens": {
 							"type": "number",
-							"default": 4000,
+							"default": 2000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -376,8 +426,13 @@
 						},
 						"max_tokens": {
 							"type": "number",
-							"default": 4000,
+							"default": 2000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -407,8 +462,13 @@
 						},
 						"max_tokens": {
 							"type": "number",
-							"default": 4000,
+							"default": 2000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -438,8 +498,13 @@
 						},
 						"max_tokens": {
 							"type": "number",
-							"default": 4000,
+							"default": 2000,
 							"description": "[optional*] The maximum number of tokens to generate in the chat completion.\nThe total length of input tokens and generated tokens is limited by the model's context length. Example Python code for counting tokens."
+						},
+						"max_input_tokens": {
+							"type": "number",
+							"default": 4000,
+							"description": "[optional*] Maximum text length for input to AI."
 						}
 					},
 					"additionalProperties": false,
@@ -454,7 +519,7 @@
 							"enum": [
 								"gpt-3.5-turbo",
 								"gpt-4",
-								"gpt-4-1106-preview",
+								"gpt-4-turbo-preview",
 								"claude-2.1",
 								"xinghuo-3.5",
 								"GLM-4",

--- a/src/topic/topicManager.ts
+++ b/src/topic/topicManager.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 
 import DevChat, { LogEntry, LogOptions, TopicEntry } from '../toolwrapper/devchat';
 
@@ -203,7 +204,10 @@ export class TopicManager {
 		// 从底层数据库中删除topic
 		// 在.chat/.deletedTopics中记录被删除的topicId
 		// get ${WORKSPACE_ROOT}/.chat/.deletedTopics
-		const workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
+		let workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
+		if (!workspaceDir) {
+			workspaceDir = os.homedir();
+		}
 		const deletedTopicsPath = path.join(workspaceDir!, '.chat', '.deletedTopics');
 
 		// read ${WORKSPACE_ROOT}/.chat/.deletedTopics as String[]
@@ -219,7 +223,10 @@ export class TopicManager {
 	}
 
 	isDeleteTopic(topicId: string) {
-		const workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
+		let workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
+		if (!workspaceDir) {
+			workspaceDir = os.homedir();
+		}
 		const deletedTopicsPath = path.join(workspaceDir!, '.chat', '.deletedTopics');
 
 		if (!fs.existsSync(deletedTopicsPath)) {

--- a/src/util/apiKey.ts
+++ b/src/util/apiKey.ts
@@ -60,7 +60,7 @@ export class ApiKeyManager {
 		if (openaiModel3) {
 			modelList.push(openaiModel3.model);
 		}
-		const openaiModel4 = await modelProperties('Model.gpt-4-turbo', "gpt-4-1106-preview");
+		const openaiModel4 = await modelProperties('Model.gpt-4-turbo', "gpt-4-turbo-preview");
 		if (openaiModel4) {
 			modelList.push(openaiModel4.model);
 		}
@@ -164,8 +164,8 @@ export class ApiKeyManager {
 		if (llmModelT === "gpt-4") {
 			return await modelProperties('Model.gpt-4', "gpt-4");
 		}
-		if (llmModelT === "gpt-4-1106-preview") {
-			return await modelProperties('Model.gpt-4-turbo', "gpt-4-1106-preview");
+		if (llmModelT === "gpt-4-turbo-preview") {
+			return await modelProperties('Model.gpt-4-turbo', "gpt-4-turbo-preview");
 		}
 		if (llmModelT === "claude-2.1") {
 			return await modelProperties('Model.claude-2', "claude-2.1");

--- a/src/util/commonUtil.ts
+++ b/src/util/commonUtil.ts
@@ -19,7 +19,7 @@ export async function saveModelSettings(): Promise<void> {
 	const supportModels = {
 		"Model.gpt-3-5": "gpt-3.5-turbo",
 		"Model.gpt-4": "gpt-4",
-		"Model.gpt-4-turbo": "gpt-4-1106-preview",
+		"Model.gpt-4-turbo": "gpt-4-turbo-preview",
 		"Model.claude-2": "claude-2.1",
 		"Model.xinghuo-2": "xinghuo-3.5",
 		"Model.chatglm_pro": "GLM-4",


### PR DESCRIPTION
This PR addresses the issue where GPT-4 exceeded the max_tokens limit despite explicit configuration settings. Changes made ensure that token limits are enforced as per user requirements, providing two separate configuration parameters for input and output token limits.

The following fixes have been made:
- A `max_input_tokens` property has been introduced to configuration settings to explicitly define the maximum number of tokens for model input.
- Default values for `max_tokens` have been adjusted to ensure that the output does not exceed the set limit.
- For consistency, the identifier `gpt-4-1106-preview` has been renamed to `gpt-4-turbo-preview`.

With these changes, users should have reliable control over the length of generated content and better clarity on token limitation configurations for both input and output.

Closes https://github.com/devchat-ai/devchat/issues/243