### PR TITLE
feat: Remove api_secret attribute from model config

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,11 +378,6 @@
 							],
 							"description": "[required*] which provider host this llm model"
 						},
-						"api_secret": {
-							"type": "string",
-							"default": "",
-							"description": "[required*] Specify secret key for selected provider."
-						},
 						"temperature": {
 							"type": "number",
 							"default": 0.5,
@@ -413,11 +408,6 @@
 								"devchat"
 							],
 							"description": "[required*] which provider host this llm model"
-						},
-						"api_secret": {
-							"type": "string",
-							"default": "",
-							"description": "[required*] Specify secret key for selected provider."
 						},
 						"temperature": {
 							"type": "number",
@@ -450,11 +440,6 @@
 							],
 							"description": "[required*] which provider host this llm model"
 						},
-						"api_secret": {
-							"type": "string",
-							"default": "",
-							"description": "[required*] Specify secret key for selected provider."
-						},
 						"temperature": {
 							"type": "number",
 							"default": 0.5,
@@ -485,11 +470,6 @@
 								"devchat"
 							],
 							"description": "[required*] which provider host this llm model"
-						},
-						"api_secret": {
-							"type": "string",
-							"default": "",
-							"description": "[required*] Specify secret key for selected provider."
 						},
 						"temperature": {
 							"type": "number",


### PR DESCRIPTION
This pull request includes changes that remove the `api_secret` attribute from the model configuration within `package.json`. The update ensures best practices for API secret management by advocating the use of environment variables or a secrets manager, rather than hardcoding secrets within configuration files.

Changes:
- Removed `api_secret` from `package.json`.
- Ensured there are no defaults or descriptions left for `api_secret`.

The implementation aligns with modern security standards and minimizes potential risks associated with code-based secret management.