### PR TITLE
Add Keyboard Shortcut for Focusing on DevChat Input

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "devchat",
 	"displayName": "DevChat",
 	"description": "Write prompts, not code",
-	"version": "0.1.55",
+	"version": "0.1.65",
 	"icon": "assets/devchat.png",
 	"publisher": "merico",
 	"engines": {
@@ -668,6 +668,13 @@
 				"command": "DevChat.Chat",
 				"title": "Chat with DevChat",
 				"category": "DevChat"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "devchat.openChatPanel",
+				"key": "ctrl+shift+/",
+				"mac": "cmd+shift+/"
 			}
 		],
 		"menus": {

--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -17,6 +17,7 @@ import DevChat from "../toolwrapper/devchat";
 import { createEnvByConda, createEnvByMamba } from '../util/python_installer/app_install';
 import { installRequirements } from '../util/python_installer/package_install';
 import { chatWithDevChat } from '../handler/chatHandler';
+import { focusDevChatInput } from '../handler/focusHandler';
 
 const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);
@@ -42,6 +43,7 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
 function registerOpenChatPanelCommand(context: vscode.ExtensionContext) {
 	let disposable = vscode.commands.registerCommand('devchat.openChatPanel', async () => {
 		await vscode.commands.executeCommand('devchat-view.focus');
+		await focusDevChatInput(ExtensionContextHolder.provider?.view()!);
 	});
 	context.subscriptions.push(disposable);
 }

--- a/src/handler/focusHandler.ts
+++ b/src/handler/focusHandler.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+import { MessageHandler } from './messageHandler';
+
+
+export async function focusDevChatInput(panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {
+    const inputFocusMessage = {"command": "focusDevChatInput"};
+    if (panel) {
+        MessageHandler.sendMessage(panel, inputFocusMessage);
+    }
+}


### PR DESCRIPTION
This pull request introduces a keyboard shortcut for opening the DevChat view and focusing on the input field, addressing the feature request outlined in [#250](https://github.com/devchat-ai/devchat/issues/250).

### Changes:
- The addition of keybindings to trigger the DevChat view and automatically move the input focus to the chat input box.
- Implementation of a focusHandler function to manage the input focus upon using the shortcut.

This feature will improve efficiency by allowing users to start discussions quickly without the need to switch from keyboard to mouse. Additionally, it will enhance the usability of DevChat for those who prioritize keyboard navigation.

Closes devchat-ai/devchat#250