### PR TITLE
feat: Implement /ide_name endpoint to retrieve IDE name

### DIFF
--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -45,6 +45,14 @@ const functionRegistry: any = {
         keys: ["abspath", "line", "character"],
         handler: findTypeDefinitionLocations,
     },
+    "/ide_name": {
+        keys: [],
+        handler: () => "vscode",
+    },
+    "/diff_apply": {
+        keys: ["filepath", "content"],
+        handler: UnofficialEndpoints.diffApply,
+    },
 
     /**
      * @deprecated
@@ -64,10 +72,6 @@ const functionRegistry: any = {
     /**
      * Unofficial endpoints
      */
-    "/diff_apply": {
-        keys: ["filepath", "content"],
-        handler: UnofficialEndpoints.diffApply,
-    },
     "/get_symbol_defines_in_selected_code": {
         keys: [],
         handler: UnofficialEndpoints.getSymbolDefinesInSelectedCode,


### PR DESCRIPTION
This PR introduces a new endpoint `/ide_name` which is responsible for returning the name of the IDE currently in use. For now, it is hardcoded to return `vscode`.

Changes include:
- Addition of a new `/ide_name` endpoint in the service layer
- Implementation of a handler that returns `vscode` as the IDE name
- Reorganization of the endpoint definition for `/diff_apply` within the functionRegistry to maintain clean code structure.

No associated issue to close.