### PR TITLE
Fix Windows File Path Case Sensitivity Issue in Patch Application

### DIFF
--- a/src/util/diffFilePairs.ts
+++ b/src/util/diffFilePairs.ts
@@ -1,3 +1,4 @@
+
 export class FilePairManager {
   private static instance: FilePairManager;
   private filePairs: Map<string, [string, string]>;
@@ -14,11 +15,12 @@ export class FilePairManager {
   }
 
   addFilePair(file1: string, file2: string): void {
-    this.filePairs.set(file1, [file1, file2]);
-    this.filePairs.set(file2, [file1, file2]);
+    this.filePairs.set(file1.toLowerCase(), [file1, file2]);
+    this.filePairs.set(file2.toLowerCase(), [file1, file2]);
   }
 
   findPair(file: string): [string, string] | undefined {
-    return this.filePairs.get(file);
+    const fileLower = file.toLowerCase();
+    return this.filePairs.get(fileLower);
   }
 }


### PR DESCRIPTION
This PR introduces a fix for the case sensitivity problem on Windows platforms when applying patches using the diff view feature. The changes ensure that file paths are normalized to lowercase before pairing and looking them up, which addresses the mismatches caused by different casing in drive letters.

The following changes have been made:
- File paths are converted to lowercase before adding to `filePairs`.
- File pairs are retrieved using lowercase file paths.

By normalizing the file path case, the tool can successfully apply modifications regardless of the case used in the drive letters, which conforms with the expected behavior reported in the issue.

Closes #255.

Refer to devchat-ai/devchat#255 for more details on the reported issue.