### PR TITLE
Streamline Log Insertion by Combining Insert and Retrieve Actions

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -283,8 +283,7 @@ class DevChat {
 			const responseData = this.parseOutData(stdout, false);
 			let promptHash = "";
 			if (saveToLog) {
-				await this.logInsert(options.context, content, responseData.response, options.parent);
-				const logs = await this.log({"maxCount": 1});
+				const logs = await this.logInsert(options.context, content, responseData.response, options.parent);
 				assertValue(!logs || !logs.length, "Failed to insert devchat log");
 				promptHash = logs[0]["hash"];
 			}
@@ -313,7 +312,7 @@ class DevChat {
 		}
 	}
 
-	async logInsert(contexts: string[] | undefined, request: string, response: string, parent: string | undefined): Promise<boolean> {
+	async logInsert(contexts: string[] | undefined, request: string, response: string, parent: string | undefined): Promise<LogEntry[]> {
 		try {
 			// build log data
 			const llmModelData = await ApiKeyManager.llmModel();
@@ -357,11 +356,16 @@ class DevChat {
 				logger.channel()?.warn(`${stderr}`);
 			}
 
-			return true;
+			const logs = JSON.parse(stdout.trim()).reverse();
+			for (const log of logs) {
+				log.response = log.responses[0];
+				delete log.responses;
+			}
+			return logs;
 		} catch (error: any) {
 			logger.channel()?.error(`Failed to insert log: ${error.message}`);
 			logger.channel()?.show();
-			return false;
+			return [];
 		}
 	}
 


### PR DESCRIPTION
This PR introduces a significant simplification to the Devchat log insertion process by integrating the previously separate log insertion and HASH retrieval steps into a single unified action.

With this change, the `logInsert` method now returns an array of `LogEntry` objects, which includes the HASH value for each new log entry immediately upon insertion. This enhancement not only streamlines the development workflow but also leverages the updated capabilities of devchat-core, aiming to improve developer experience and efficiency.

Care has been taken to ensure backward compatibility, as existing code relying on the older implementation has been adapted to accommodate the new return structure.

By merging this PR, we will be closing the associated issue which suggested this improvement. The detailed discussion and rationale for this change can be found at the issue tracker link below.

Closes https://github.com/devchat-ai/devchat/issues/256