### PR TITLE
Fix: Trim whitespace from OPENAI_API_KEY to prevent misleading 'APIConnectionError'

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -248,7 +248,7 @@ class DevChat {
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				"PYTHONPATH": UiUtilWrapper.extensionPath() + "/tools/site-packages",
 				// eslint-disable-next-line @typescript-eslint/naming-convention
-				"OPENAI_API_KEY": llmModelData.api_key,
+				"OPENAI_API_KEY": llmModelData.api_key.trim(),
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				...llmModelData.api_base? { "OPENAI_API_BASE": llmModelData.api_base, "OPENAI_BASE_URL": llmModelData.api_base } : {}
 			};


### PR DESCRIPTION
This pull request addresses the issue where an API key containing leading or trailing whitespaces could cause a misleading `openai.APIConnectionError`. By trimming whitespace from the `OPENAI_API_KEY`, we prevent the `h11._util.LocalProtocolError: Illegal header value` error and ensure that the key is in a valid format before initiating network requests, improving error clarity and user experience.

Closes devchat-ai/devchat#265