### PR TITLE
Fix Docstring Function Selection Range to Include Last Line

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -470,7 +470,7 @@ export function registerCodeLensRangeCommand(context: vscode.ExtensionContext) {
       if (editor) {
         const range = new vscode.Range(
           new vscode.Position(pos.start, 0),
-          new vscode.Position(pos.end, 0)
+          new vscode.Position(pos.end+1, 0)
         );
         editor.selection = new vscode.Selection(range.start, range.end);
       }


### PR DESCRIPTION
This PR addresses the issue where the selection range for functions in docstrings was not including the last line, leading to line duplication during code refactoring.

Changes:
- The selection range for function docstrings now correctly includes the last line.
- This fix prevents line duplication and ensures accurate function extraction during refactoring.

Closes devchat-ai/devchat#291