### PR TITLE
Fix: Trim spaces from OPENAI_API_KEY to prevent misleading APIConnectionError

### DIFF
--- a/src/toolwrapper/devchat.ts
+++ b/src/toolwrapper/devchat.ts
@@ -248,7 +248,7 @@ class DevChat {
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				"PYTHONPATH": UiUtilWrapper.extensionPath() + "/tools/site-packages",
 				// eslint-disable-next-line @typescript-eslint/naming-convention
-				"OPENAI_API_KEY": llmModelData.api_key,
+				"OPENAI_API_KEY": llmModelData.api_key.trim(),
 				// eslint-disable-next-line @typescript-eslint/naming-convention
 				...llmModelData.api_base? { "OPENAI_API_BASE": llmModelData.api_base, "OPENAI_BASE_URL": llmModelData.api_base } : {}
 			};


### PR DESCRIPTION
## **User description**
This PR addresses the issue where spaces in the OPENAI_API_KEY lead to a misleading `openai.APIConnectionError`. Spaces in the API key can create `h11._util.LocalProtocolError`, which was incorrectly presented as a connection error. With this change, the key is trimmed to remove any leading or trailing spaces before use, ensuring the error messages are accurate and not misleading.

Changes include:
- Adding `.trim()` to OPENAI_API_KEY processing.

The implementation aims to give users clear and proper error messaging and prevent confusion over network connection issues when the real problem is an incorrectly formatted key.

Resolves: https://github.com/devchat-ai/devchat/issues/297


___

## **Type**
bug_fix


___

## **Description**
- Fixes an issue where spaces in `OPENAI_API_KEY` could lead to misleading `openai.APIConnectionError`.
- Ensures `OPENAI_API_KEY` is properly formatted by trimming leading and trailing spaces.
- Aims to provide clear and accurate error messaging to users.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devchat.ts</strong><dd><code>Trim Spaces from OPENAI_API_KEY to Prevent Misleading Errors</code></dd></summary>
<hr>
      
src/toolwrapper/devchat.ts

<li>Added <code>.trim()</code> to <code>OPENAI_API_KEY</code> to remove leading and trailing spaces.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/devchat-ai/devchat-vscode/pull/468/files#diff-767083ebd7685a9d23cc75b6292b5bdaa1dd2a347f677ed41bb1342339c2d612">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

