### PR TITLE
Fix: Improve line filtering logic for better code completion

### DIFF
--- a/src/contributes/codecomplete/chunkFilter.ts
+++ b/src/contributes/codecomplete/chunkFilter.ts
@@ -187,8 +187,7 @@ export class LLMStreamComplete {
             if (index > 0 && preIndent === 0 && lineIndent === 0) {
                 break;
             }
-            if (index > 0 && hasIndentBigger && lineIndent === this.curlineIndent && chunk.text.trim().length > 3) {
-                yield chunk;
+            if (index > 0 && hasIndentBigger && lineIndent === this.curlineIndent && chunk.text.trim().length > 0 && ![')',']', '}'].includes(chunk.text.trim()[0])) {
                 break;
             }
             if (lineIndent > this.curlineIndent) {


### PR DESCRIPTION
This PR introduces improvements to the line filtering process in the code completion feature:

- Lines that are empty or start with `)`, `]`, or `}` are now properly excluded from consideration.
- The chunk filtering logic has been optimized for enhanced accuracy in code completion results.

The adjustments should yield a smoother experience with more precise code completions.