### PR TITLE
Fix initialization issue when Devchat is not previously installed in VSCode

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -28,8 +28,14 @@ export class DevChatConfig {
 
     private readConfigFile() {
         try {
+            // if config file not exist, create a empty file
+            if (!fs.existsSync(this.configFilePath)) {
+                fs.mkdirSync(path.dirname(this.configFilePath), { recursive: true });
+                fs.writeFileSync(this.configFilePath, '', 'utf8');
+            }
+
             const fileContents = fs.readFileSync(this.configFilePath, 'utf8');
-            this.data = yaml.parse(fileContents);
+            this.data = yaml.parse(fileContents) ?? {};
             this.lastModifyTime = fs.statSync(this.configFilePath).mtimeMs;
         } catch (error) {
 			logger.channel()?.error(`Error reading the config file: ${error}`);
@@ -75,7 +81,12 @@ export class DevChatConfig {
         }
         
         let lastKey = keys.pop();
-        let lastObj = keys.reduce((prev, k) => prev[k] = prev[k] || {}, this.data); // 这创建一个嵌套的对象结构，如果不存在的话
+        let lastObj = keys.reduce((prev, k) => {
+            if (!prev[k]) {
+                prev[k] = {};
+            }
+            return prev[k];
+        }, this.data); // 这创建一个嵌套的对象结构，如果不存在的话
         if (lastKey) {
             lastObj[lastKey] = value; // 设置值
         }


### PR DESCRIPTION
This PR addresses the problem reported in [#347](https://github.com/devchat-ai/devchat/issues/347) where Devchat fails to render correctly in VSCode if it has never been installed on the machine before. This was due to missing provider information that led to exceptions in the application flow.

Changes include:
- Ensuring that the configuration file is checked for existence and created if it does not exist.
- Parsing the configuration file into an object, even if it is initially empty, to prevent loading issues.
- Refactoring of configuration and value-setting logic to improve clarity and stability.

Additionally, subproject commit hashes have been updated in the GUI and tools directories to align with the latest changes.

Resolves devchat-ai/devchat#347.