### PR TITLE
Update GUI Submodule and Remove Unused DevChat Install Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -692,11 +692,6 @@
         "category": "DevChat"
       },
       {
-        "command": "DevChat.InstallCommandPython",
-        "title": "Install Python for Commands",
-        "category": "DevChat"
-      },
-      {
         "command": "DevChat.Chat",
         "title": "Chat with DevChat",
         "category": "DevChat"

--- a/src/panel/statusBarView.ts
+++ b/src/panel/statusBarView.ts
@@ -52,7 +52,7 @@ export function createStatusBarItem(context: vscode.ExtensionContext): vscode.St
 			if (!hasInstallCommands) {
 				hasInstallCommands = true;
 				await vscode.commands.executeCommand('DevChat.InstallCommands');
-				vscode.commands.executeCommand('DevChat.InstallCommandPython');
+				// vscode.commands.executeCommand('DevChat.InstallCommandPython');
 			}
 			
 			clearInterval(timer);


### PR DESCRIPTION
In this pull request, two key changes have been made to improve the project's configuration and codebase:

1. The commit hash for the GUI submodule has been updated to integrate the latest changes.
2. The unnecessary DevChat installation commands for Python have been removed from the `package.json` and the corresponding execution lines in `statusBarView.ts` are commented out, ensuring that these commands are no longer triggered upon status bar item creation.

These changes streamline the project setup process and reduce potential for confusion or errors related to the DevChat install commands.