### PR TITLE
Fix custom API Base URL causing illegal errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,16 @@ async function migrateConfig() {
 	}
 }
 
+// fix devchat api base is "custom"
+export async function fixDevChatApiBase() {
+	const devchatConfig = DevChatConfig.getInstance();
+	const devchatProvider = "providers.devchat";
+	const devchatProviderConfig: any = devchatConfig.get(devchatProvider);
+	if (!devchatProviderConfig || devchatProviderConfig["api_base"] === "custom") {
+		devchatConfig.set("providers.devchat.api_base", "https://api.devchat.ai/v1");
+	}
+}
+
 async function activate(context: vscode.ExtensionContext) {
   ExtensionContextHolder.context = context;
 
@@ -164,6 +174,8 @@ async function activate(context: vscode.ExtensionContext) {
   logger.channel()?.info(`registerHandleUri:`);
   registerHandleUri(context);
   registerQuickFixProvider();
+
+  fixDevChatApiBase();
 
   const workspaceDir = UiUtilWrapper.workspaceFoldersFirstPath();
   if (workspaceDir) {


### PR DESCRIPTION
This PR addresses the issue where the API Base URL was being inadvertently set to a custom value for some users, causing an illegal API base error.

The changes include:
- Ensuring that the API base URL is correctly fixed to prevent the illegal base error
- Setting the default API base URL to https://api.devchat.ai/v1
- Invoking the fixDevChatApiBase function during the activate method to apply this fix

Closes devchat-ai/devchat#386