### PR TITLE
Update log level from warn to debug in services.ts

### DIFF
--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -166,7 +166,7 @@ export async function startRpcServer() {
 							responseResult["result"] = res;
 						}
 					} catch (error) {
-						logger.channel()?.warn(`warning: ${error}`);
+						logger.channel()?.debug(`warning: ${error}`);
 						responseResult["result"] = res;
 					}
                     


### PR DESCRIPTION
This small change updates the logger to use debug level instead of warn for better clarity during development.