### PR TITLE
feat: Add getCurrentFileInfo and getIDEServicePort handlers

### DIFF
--- a/src/handler/fileHandler.ts
+++ b/src/handler/fileHandler.ts
@@ -30,3 +30,30 @@ export async function readFile(message: any, panel: vscode.WebviewPanel | vscode
         logger.channel()?.error(`Error reading file ${message.file}: ${error}`);
     }
 }
+
+regInMessage({ command: 'getCurrentFileInfo'});
+regOutMessage({ command: 'getCurrentFileInfo', result: '' });
+// Read content from specified file and return it
+export async function getCurrentFileInfo(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
+    try {
+        // 获取当前文件的绝对路径
+        const fileUri = vscode.window.activeTextEditor?.document.uri;
+        const filePath = fileUri?.fsPath;
+        MessageHandler.sendMessage(panel, { command: 'getCurrentFileInfo', result: filePath ?? "" });
+    } catch (error) {
+        logger.channel()?.error(`Error getting current file info: ${error}`);
+    }
+}
+
+regInMessage({ command: 'getIDEServicePort'});
+regOutMessage({ command: 'getIDEServicePort', result: 8090 });
+// Read content from specified file and return it
+export async function getIDEServicePort(message: any, panel: vscode.WebviewPanel | vscode.WebviewView): Promise<void> {
+    try {
+        // Get IDE service port
+        const port = process.env.DEVCHAT_IDE_SERVICE_PORT;
+        MessageHandler.sendMessage(panel, { command: 'getIDEServicePort', result: port ?? 0 });
+    } catch (error) {
+        logger.channel()?.error(`Error getting IDE service port: ${error}`);
+    }
+}

--- a/src/handler/handlerRegister.ts
+++ b/src/handler/handlerRegister.ts
@@ -13,7 +13,7 @@ import {createAndOpenFile} from './codeBlockHandler';
 import { listAllMessages } from './listMessages';
 import { doVscodeCommand } from './vscodeCommandHandler';
 import { featureToggle, getFeatureToggles } from './featureToggleHandler';
-import { readFile, writeFile } from './fileHandler';
+import { readFile, writeFile, getIDEServicePort, getCurrentFileInfo } from './fileHandler';
 import { getTopics, deleteTopic } from './topicHandler';
 import { readConfig, writeConfig, readServerConfigBase, writeServerConfigBase } from './configHandler';
 import { getSetting, getUserAccessKey, getValidLlmModelList, updateSetting } from './removehandler';
@@ -85,6 +85,9 @@ messageHandler.registerHandler('deleteTopic', deleteTopic);
 
 messageHandler.registerHandler('readConfig', readConfig);
 messageHandler.registerHandler('writeConfig', writeConfig);
+
+messageHandler.registerHandler('getCurrentFileInfo', getCurrentFileInfo);
+messageHandler.registerHandler('getIDEServicePort', getIDEServicePort);
 
 messageHandler.registerHandler('readServerConfigBase', readServerConfigBase);
 messageHandler.registerHandler('writeServerConfigBase', writeServerConfigBase);

--- a/src/ide_services/endpoints/getCurrentFileInfo.ts
+++ b/src/ide_services/endpoints/getCurrentFileInfo.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export async function getCurrentFileInfo() {
+    const fileUri = vscode.window.activeTextEditor?.document.uri;
+    const filePath = fileUri?.fsPath;
+    return {"path": filePath ?? ""};
+}

--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -13,6 +13,7 @@ import { UnofficialEndpoints } from "./endpoints/unofficial";
 import { getDocumentSymbols } from "./endpoints/getDocumentSymbols";
 import { findTypeDefinitionLocations } from "./endpoints/findTypeDefs";
 import { findDefinitionLocations } from "./endpoints/findDefs";
+import { getCurrentFileInfo } from "./endpoints/getCurrentFileInfo";
 
 const functionRegistry: any = {
     /**
@@ -85,6 +86,10 @@ const functionRegistry: any = {
 		keys: ["code"],
 		handler: UnofficialEndpoints.runCode,
 	},
+    "/getCurrentFileInfo": {
+        keys: [],
+        handler: getCurrentFileInfo,
+    }
 };
 
 let server: http.Server | null = null;


### PR DESCRIPTION
feat: Add getCurrentFileInfo and getIDEServicePort handlers

- Added getCurrentFileInfo handler to retrieve the absolute path of the current file
- Added getIDEServicePort handler to retrieve the IDE service port
- Updated fileHandler.ts and handlerRegister.ts to include the new handlers
- Created getCurrentFileInfo.ts in ide_services/endpoints to implement the getCurrentFileInfo handler
- Updated services.ts in ide_services to include the getCurrentFileInfo handler