### PR TITLE
feat: Add new IDE service endpoints and refactor quick fix command

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -352,15 +352,17 @@ export function registerFixCommand(context: vscode.ExtensionContext) {
 export async function registerQuickFixCommand(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
       "DevChat.quickFix",
-      async (diagnosticMessage: string, code: string, surroundingCode: string) => {
+      async (document: vscode.TextDocument, range: vscode.Range | vscode.Selection, diagnostic: vscode.Diagnostic) => {
           ensureChatPanel(context);
           if (!ExtensionContextHolder.provider?.view()) {
               await waitForPanelActivation();
           }
 
-          const language = DevChatConfig.getInstance().get('language');
-          const prompt = await generatePrompt(code, surroundingCode, diagnosticMessage, language);
-          chatWithDevChat(ExtensionContextHolder.provider?.view()!, prompt);
+          // select the code
+          const editor = vscode.window.activeTextEditor;
+          editor!.selection = new vscode.Selection(range.start, range.end);
+
+          chatWithDevChat(ExtensionContextHolder.provider?.view()!, "/fix_issue ");
       }
   );
 

--- a/src/contributes/quickFixProvider.ts
+++ b/src/contributes/quickFixProvider.ts
@@ -24,22 +24,13 @@ class DevChatQuickFixProvider implements vscode.CodeActionProvider {
         quickFix.isPreferred = false;
 
         return new Promise(async (resolve) => {
-            const code = await collapseFileExculdeSelectRange(document.uri.fsPath, document.getText(), range.start.line, range.end.line);
-
-            const surroundingRange = new vscode.Range(
-                Math.max(0, range.start.line - 3),
-                0,
-                Math.min(document.lineCount, range.end.line + 3),
-                0,
-            );
-
             quickFix.command = {
                 command: "DevChat.quickFix",
                 title: "DevChat Quick Fix",
                 arguments: [
-                    diagnostic.message,
-                    code,
-                    document.getText(surroundingRange)
+                    document,
+                    range,
+                    diagnostic,
                 ],
             };
 

--- a/src/ide_services/endpoints/documentRangeDiagnostics.ts
+++ b/src/ide_services/endpoints/documentRangeDiagnostics.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+
+export async function getDiagnosticsInRange(fileName: string, startLine: number, endLine: number): Promise<string[]> {
+    const document = await vscode.workspace.openTextDocument(fileName);
+    const startPosition = new vscode.Position(startLine, 0);
+    const endPosition = new vscode.Position(endLine, Number.MAX_VALUE);
+    const range = new vscode.Range(startPosition, endPosition);
+    const diagnosticsAll = vscode.languages.getDiagnostics(document.uri);
+
+    const diagnostics = diagnosticsAll.filter(diag => range.contains(diag.range));
+    return diagnostics.map(diag => { return `${diag.message} <<${diag.source??""}:${diag.code??""}>>`; });
+}

--- a/src/ide_services/endpoints/getCollapsedCode.ts
+++ b/src/ide_services/endpoints/getCollapsedCode.ts
@@ -1,0 +1,11 @@
+import { collapseFileExculdeSelectRange } from '../../contributes/codecomplete/ast/collapseBlock';
+import * as vscode from 'vscode';
+
+export async function getCollapsedCode(fileName: string, startLine: number, endLine: number): Promise<string> {
+    const document = await vscode.workspace.openTextDocument(fileName);
+    const startPosition = new vscode.Position(startLine, 0);
+    const endPosition = new vscode.Position(endLine, Number.MAX_VALUE);
+    const range = new vscode.Range(startPosition, endPosition);
+    const code = await collapseFileExculdeSelectRange(document.uri.fsPath, document.getText(), range.start.line, range.end.line);
+    return code;
+}

--- a/src/ide_services/endpoints/getToolsPath.ts
+++ b/src/ide_services/endpoints/getToolsPath.ts
@@ -1,0 +1,6 @@
+import { UiUtilWrapper } from "../../util/uiUtil";
+
+
+export async function getExtensionToolsPath(): Promise<string> {
+    return await UiUtilWrapper.extensionPath() + "/tools/";
+}

--- a/src/ide_services/services.ts
+++ b/src/ide_services/services.ts
@@ -14,6 +14,9 @@ import { getDocumentSymbols } from "./endpoints/getDocumentSymbols";
 import { findTypeDefinitionLocations } from "./endpoints/findTypeDefs";
 import { findDefinitionLocations } from "./endpoints/findDefs";
 import { getCurrentFileInfo } from "./endpoints/getCurrentFileInfo";
+import { getDiagnosticsInRange } from "./endpoints/documentRangeDiagnostics";
+import { getExtensionToolsPath } from "./endpoints/getToolsPath";
+import { getCollapsedCode } from "./endpoints/getCollapsedCode";
 
 const functionRegistry: any = {
     /**
@@ -89,6 +92,18 @@ const functionRegistry: any = {
     "/current_file_info": {
         keys: [],
         handler: getCurrentFileInfo,
+    },
+    "/get_diagnostics_in_range": {
+        keys: ["fileName", "startLine", "endLine"],
+        handler: getDiagnosticsInRange,
+    },
+    "/get_extension_tools_path": {
+        keys: [],
+        handler: getExtensionToolsPath,
+    },
+    "/get_collapsed_code": {
+        keys: ["fileName", "startLine", "endLine"],
+        handler: getCollapsedCode,
     }
 };
 


### PR DESCRIPTION
This PR adds new IDE service endpoints and refactors the quick fix command implementation.

Changes include:
- Implementing getDiagnosticsInRange for code diagnostics
- Creating getCollapsedCode for code collapsing functionality
- Adding getExtensionToolsPath to retrieve tools directory
- Updating services.ts with new endpoint handlers
- Refactoring quick fix command to use document, range, and diagnostic
- Removing code collapsing and surrounding code extraction
- Updating command arguments to pass document, range, and diagnostic

These changes improve the functionality and efficiency of the IDE services and quick fix command.