### PR TITLE
feat: Update stop tokens in devchatComplete function

### DIFF
--- a/src/contributes/codecomplete/llm.ts
+++ b/src/contributes/codecomplete/llm.ts
@@ -206,7 +206,7 @@ export async function * devchatComplete(prompt: string) : AsyncGenerator<CodeCom
 	    model: model,
 	    prompt: prompt,
 	    stream: true,
-	    stop: ["<|endoftext|>", "<|EOT|>", "<file_sep>", "```", "//", "\n\n"],
+	    stop: ["<|endoftext|>", "<|EOT|>", "<file_sep>", "\n\n"],
 	    temperature: 0.2
 	};
 


### PR DESCRIPTION
This PR updates the stop tokens in the devchatComplete function to improve code completion behavior. The changes include:

- Removing "```" and "//" from the stop tokens list
- Retaining "<|endoftext|>", "<|EOT|>", "<file_sep>", and "\n\n" as stop tokens
- Adjusting the code completion behavior for improved results

These modifications aim to enhance the accuracy and effectiveness of the code completion functionality.