### PR TITLE
feat: Add logging for local service port

### DIFF
--- a/src/toolwrapper/devchatClient.ts
+++ b/src/toolwrapper/devchatClient.ts
@@ -155,6 +155,7 @@ export class DevChatClient {
                 logger.channel()?.info("No local service port found.");
                 throw new DCLocalServicePortNotSetError();
             }
+            logger.channel()?.trace("Using local service port:", process.env.DC_LOCALSERVICE_PORT);
             const port: number = parseInt(process.env.DC_LOCALSERVICE_PORT || '8008', 10);
             this.baseURL = `http://localhost:${port}`;
         }
@@ -174,6 +175,7 @@ export class DevChatClient {
                 logger.channel()?.info("No local service port found.");
                 throw new DCLocalServicePortNotSetError();
             }
+            logger.channel()?.trace("Using local service port:", process.env.DC_LOCALSERVICE_PORT);
             const port: number = parseInt(process.env.DC_LOCALSERVICE_PORT || '8008', 10);
             this.baseURL = `http://localhost:${port}`;
         }
@@ -251,6 +253,7 @@ export class DevChatClient {
             if (!process.env.DC_LOCALSERVICE_PORT) {
                 logger.channel()?.info("No local service port found.");
             }
+            logger.channel()?.trace("Using local service port:", process.env.DC_LOCALSERVICE_PORT);
             const port: number = parseInt(process.env.DC_LOCALSERVICE_PORT || '8008', 10);
             this.baseURL = `http://localhost:${port}`;
         }


### PR DESCRIPTION
This PR adds trace logging for the local service port in DevChatClient to enhance debugging capabilities for local service connections.

Changes:
- Add trace logging in DevChatClient constructor
- Implement logging in reset method
- Add logging in setLocalServicePort method

This improvement will help with troubleshooting and monitoring local service connections.