### PR TITLE
chore: Add cleanup for existing Merico workflow directory

### DIFF
--- a/src/contributes/commands.ts
+++ b/src/contributes/commands.ts
@@ -219,6 +219,9 @@ export function registerInstallCommandsCommand(
       let copiedDirectory = false;
       if (!fs.existsSync(sysMericoDirPath) || (updatePublicWorkflow === false && currentVersion !== previousVersion)) {
         logger.channel()?.debug("Creating directory: " + sysMericoDirPath);
+        if (fs.existsSync(sysMericoDirPath)) {
+          fs.rmSync(sysMericoDirPath, { recursive: true, force: true });
+        }
         await copyDirectory(pluginDirPath, sysDirPath);
         copiedDirectory = true;
       }


### PR DESCRIPTION
- Add safety check to remove existing workflow directory if present
- Ensure clean installation by removing old files before copying
- Prevent potential conflicts during version updates