### PR TITLE
refactor: Remove unused imports in openlinkHandler

### DIFF
--- a/src/handler/openlinkHandler.ts
+++ b/src/handler/openlinkHandler.ts
@@ -2,15 +2,8 @@
 Commands for handling configuration read and write
 */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
-import yaml from 'yaml';
-import { regInMessage, regOutMessage } from '../util/reg_messages';
-import { MessageHandler } from './messageHandler';
-import { DevChatConfig } from '../util/config';
-import { logger } from '../util/logger';
-
+import { regInMessage } from '../util/reg_messages';
 
 regInMessage({command: 'openLink', url: 'http://...'}); // when key is "", it will rewrite all config values
 export async function openLink(message: any, panel: vscode.WebviewPanel|vscode.WebviewView): Promise<void> {


### PR DESCRIPTION
- Remove unnecessary fs, path, yaml imports
- Remove unused MessageHandler, DevChatConfig imports
- Remove logger import while keeping required regInMessage